### PR TITLE
fix: apple touch icon not showing

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -39,7 +39,7 @@ const socialImageURL = new URL(
 
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
-    <link rel="apple-touch-icon" sizes="192x192" href="touch-icon.png" />
+    <link rel="apple-touch-icon" sizes="192x192" href="/touch-icon.png" />
     <link rel="canonical" href={canonicalURL} />
     <meta name="generator" content={Astro.generator} />
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
	- Appleタッチアイコンのパス参照を修正し、サイトのルートから正しく読み込まれるよう調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->