### PR TITLE
feat: add contents icons

### DIFF
--- a/src/components/AboutMe.astro
+++ b/src/components/AboutMe.astro
@@ -1,9 +1,6 @@
 ---
-import gitHubContribution from "@assets/contribution/github_contribution.png";
-import gitLabContribution from "@assets/contribution/gitlab_contribution.png";
 import Socials from "@components/Socials.astro";
 import { SITE } from "@config";
-import { Image } from "astro:assets";
 ---
 
 <div class="about-me">
@@ -18,29 +15,24 @@ import { Image } from "astro:assets";
 <div class="pb-8">
   <Socials />
 </div>
-<div class="pb-8">
-  <p class="pb-2">
-    <a
-      class="link link-primary"
-      href="https://github.com/s-hirano-ist"
-      target="_blank">GitHub</a
-    >
-    contributions (mainly on private repositories. Last updated on 14th of August
-    2024.)
-  </p>
-  <Image src={gitHubContribution} class="w-full" alt="gitHub contributions" />
-</div>
 <div>
-  <p class="pb-2">
-    <a
-      class="link link-primary"
-      href="https://gitlab.com/s-hirano-ist"
-      target="_blank">GitLab</a
-    >
-    contributions (Only on private repositories. Last updated on 26th of November
-    2023.)
-  </p>
-  <Image src={gitLabContribution} class="w-full" alt="gitLab contributions" />
+  <div class="grid grid-cols-2 gap-4">
+    <img
+      alt="my skills"
+      class="col-span-2 w-full"
+      src="https://skillicons.dev/icons?theme=dark&perline=7&i=next,astro,react,nodejs,ts,js,html,css,python,swift,docker,aws,cloudflare,bash"
+    />
+    <img
+      alt="Top Langs"
+      class="h-96 w-full"
+      src="https://github-readme-stats.vercel.app/api?username=s-hirano-ist&theme=vue-dark&layout=compact"
+    />
+    <img
+      alt="github stats"
+      class="h-96 w-full"
+      src="https://github-readme-stats.vercel.app/api/top-langs/?username=s-hirano-ist&theme=vue-dark&layout=compact"
+    />
+  </div>
 </div>
 <style>
   .about-me p {

--- a/src/components/TechStack.astro
+++ b/src/components/TechStack.astro
@@ -1,3 +1,9 @@
+---
+import gitHubContribution from "@assets/contribution/github_contribution.png";
+import gitLabContribution from "@assets/contribution/gitlab_contribution.png";
+import { Image } from "astro:assets";
+---
+
 <div>
   <div>
     <h3 class="py-2">実務経験</h3>
@@ -23,4 +29,28 @@
     </a>
     をクリック
   </p>
+  <div class="py-8">
+    <p class="pb-2">
+      <a
+        class="link link-primary"
+        href="https://github.com/s-hirano-ist"
+        target="_blank">GitHub</a
+      >
+      contributions (mainly on private repositories. Last updated on 14th of August
+      2024.)
+    </p>
+    <Image src={gitHubContribution} class="w-full" alt="gitHub contributions" />
+  </div>
+  <div>
+    <p class="pb-2">
+      <a
+        class="link link-primary"
+        href="https://gitlab.com/s-hirano-ist"
+        target="_blank">GitLab</a
+      >
+      contributions (Only on private repositories. Last updated on 26th of November
+      2023.)
+    </p>
+    <Image src={gitLabContribution} class="w-full" alt="gitLab contributions" />
+  </div>
 </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能  
  - Tech Stack セクションに、GitHub と GitLab の貢献状況を視覚的に表示する新しいエリアを追加しました。利用者は、各プラットフォームへのリンクや最新の更新情報を確認できます。

- リファクタリング  
  - About Me セクションのレイアウトを刷新し、従来の貢献画像を廃止。代わりに、スキルアイコンと GitHub 統計情報を強調する新しいデザインに変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->