### PR TITLE
fix: design of about me

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,7 +7,7 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeSlug from "rehype-slug";
 // import remarkMermaid from "remark-mermaidjs";
 import remarkToc from "remark-toc";
-// eslint-disable-next-line no-restricted-imports
+
 import { SITE } from "./src/config";
 
 const IS_DEV = import.meta.env.MODE === "development";

--- a/src/components/AboutMe.astro
+++ b/src/components/AboutMe.astro
@@ -16,20 +16,20 @@ import { SITE } from "@config";
   <Socials />
 </div>
 <div>
-  <div class="grid grid-cols-2 gap-4">
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-8">
     <img
       alt="my skills"
-      class="col-span-2 w-full"
+      class="w-full sm:col-span-2"
       src="https://skillicons.dev/icons?theme=dark&perline=7&i=next,astro,react,nodejs,ts,js,html,css,python,swift,docker,aws,cloudflare,bash"
     />
     <img
       alt="Top Langs"
-      class="h-96 w-full"
+      class="w-full"
       src="https://github-readme-stats.vercel.app/api?username=s-hirano-ist&theme=vue-dark&layout=compact"
     />
     <img
       alt="github stats"
-      class="h-96 w-full"
+      class="w-full"
       src="https://github-readme-stats.vercel.app/api/top-langs/?username=s-hirano-ist&theme=vue-dark&layout=compact"
     />
   </div>


### PR DESCRIPTION
Fixes #954 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - AboutMeコンポーネントの画像グリッドレイアウトを改善しました。これにより、画面サイズに応じたシングルカラムと2カラムのレスポンシブ表示が実現され、各画像間のスペースも最適化され、より見やすいレイアウトになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->